### PR TITLE
fix: allow users to override subpath for PVCs

### DIFF
--- a/charts/langtrace/Chart.yaml
+++ b/charts/langtrace/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: langtrace
 description: A Helm chart for self-hosting Langtrace
-version: 1.1.0
+version: 1.1.1
 type: application
 appVersion: "1.16.0"
 sources:

--- a/charts/langtrace/templates/deployment-clickhouse-db.yaml
+++ b/charts/langtrace/templates/deployment-clickhouse-db.yaml
@@ -30,6 +30,9 @@ spec:
           volumeMounts:
           - mountPath: /var/lib/clickhouse
             name: clickhouse-volume
+            {{- if .Values.clickhouse.subPath }}
+            subPath: {{ .Values.clickhouse.subPath }}
+            {{- end}}
       volumes:
         - name: clickhouse-volume
           persistentVolumeClaim:

--- a/charts/langtrace/templates/deployment-postgres-db.yaml
+++ b/charts/langtrace/templates/deployment-postgres-db.yaml
@@ -28,6 +28,9 @@ spec:
           volumeMounts:
           - mountPath: /var/lib/postgresql/data
             name: postgres-volume
+            {{- if .Values.postgres.subPath }}
+            subPath: {{ .Values.postgres.subPath }}
+            {{- end}}
       volumes:
         - name: postgres-volume
           persistentVolumeClaim:

--- a/charts/langtrace/templates/pvc-clickhouse-db.yaml
+++ b/charts/langtrace/templates/pvc-clickhouse-db.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "langtrace.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.clickhouse.storageClassName }}
+  storageClassName: {{ .Values.clickhouse.storageClassName }}
+  {{- end }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/charts/langtrace/templates/pvc-postgres-db.yaml
+++ b/charts/langtrace/templates/pvc-postgres-db.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "langtrace.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.postgres.storageClassName }}
+  storageClassName: {{ .Values.postgres.storageClassName }}
+  {{- end }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/charts/langtrace/values.yaml
+++ b/charts/langtrace/values.yaml
@@ -24,6 +24,7 @@ postgres:
   imagePullPolicy: IfNotPresent
   containerPort: 5432
   storageSize: 10Gi
+  # storageClassName: gp2
   # subPath: pg-data   # Uncomment this line to use subPath
 
 clickhouse:
@@ -32,6 +33,7 @@ clickhouse:
   image: clickhouse/clickhouse-server:24.5.1.1763-alpine
   imagePullPolicy: IfNotPresent
   # subPath: clickhouse-data   # Uncomment this line to use subPath
+  # storageClassName: gp2
   containerPorts:
     - 8123
     - 9000

--- a/charts/langtrace/values.yaml
+++ b/charts/langtrace/values.yaml
@@ -24,12 +24,14 @@ postgres:
   imagePullPolicy: IfNotPresent
   containerPort: 5432
   storageSize: 10Gi
+  # subPath: pg-data   # Uncomment this line to use subPath
 
 clickhouse:
   enabled: true
   name: langtrace-clickhouse
   image: clickhouse/clickhouse-server:24.5.1.1763-alpine
   imagePullPolicy: IfNotPresent
+  # subPath: clickhouse-data   # Uncomment this line to use subPath
   containerPorts:
     - 8123
     - 9000


### PR DESCRIPTION
# Description

handles issues when mounting to a volume with existing files by allowing users to have a `subPath` and `storageClass` for their PV for both databases.

# Checklist

- [x] I have updated the version number in the `Chart.yaml` file(when file inside [charts](/charts/) folder is updated).
- [ ] I have updated the [README.md](/README.md).
- [ ] I have updated the [Langtrace docs](https://github.com/Scale3-Labs/langtrace-docs) with the new changes.
